### PR TITLE
Skip crashing spotify

### DIFF
--- a/lilypadApp/src/commonMain/kotlin/gay/lilyy/lilypad/core/modules/modules/spotify/Spotify.kt
+++ b/lilypadApp/src/commonMain/kotlin/gay/lilyy/lilypad/core/modules/modules/spotify/Spotify.kt
@@ -193,8 +193,8 @@ class Spotify : ChatboxModule<SpotifyConfig>() {
 
     override fun init() {
         super.init()
-
-        Spotube.init()
+        Napier.d("Init Spotify")
+//        Spotube.init()
 
 
         // Call the suspend updateNowPlaying function every 5 seconds in Dispatchers.IO


### PR DESCRIPTION
This is a dirty workaround to be able to start it

close #1